### PR TITLE
Only commit/rollback if transaction is active

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/util/jpa/JPATransactionInterceptor.java
+++ b/src/main/java/br/com/caelum/vraptor/util/jpa/JPATransactionInterceptor.java
@@ -45,19 +45,15 @@ public class JPATransactionInterceptor implements Interceptor {
 		this.validator = validator;
 	}
 
-    //TODO I think that transaction null check is unnecessary, since we never get null transation (garcia-jj)
 	public void intercept(InterceptorStack stack, ResourceMethod method, Object instance) {
 		EntityTransaction transaction = null;
 		try {
-			transaction = manager.getTransaction();
-			
-			if (transaction != null) {
-			    transaction.begin();
-			}
+		    transaction = manager.getTransaction();
+		    transaction.begin();
 			
 			stack.next(method, instance);
 			
-			if (transaction != null && !validator.hasErrors()) {
+			if (!validator.hasErrors() && transaction.isActive()) {
 				transaction.commit();
 			}
 		} finally {

--- a/src/test/java/br/com/caelum/vraptor/util/jpa/JPATransactionInterceptorTest.java
+++ b/src/test/java/br/com/caelum/vraptor/util/jpa/JPATransactionInterceptorTest.java
@@ -38,7 +38,7 @@ public class JPATransactionInterceptorTest {
         JPATransactionInterceptor interceptor = new JPATransactionInterceptor(entityManager, validator);
 
         when(entityManager.getTransaction()).thenReturn(transaction);
-        when(transaction.isActive()).thenReturn(false);
+        when(transaction.isActive()).thenReturn(true);
 
         interceptor.intercept(stack, method, instance);
 
@@ -99,18 +99,6 @@ public class JPATransactionInterceptorTest {
         verify(transaction, never()).rollback();
     }
 
-    @Test
-    public void doNothingIfHasNoActiveTransationAsNull() {
-        JPATransactionInterceptor interceptor = new JPATransactionInterceptor(entityManager, validator);
-
-        when(entityManager.getTransaction()).thenReturn(null);
-        when(validator.hasErrors()).thenReturn(false);
-
-        interceptor.intercept(stack, method, instance);
-
-        verify(transaction, never()).rollback();
-    }
-    
     @Test
     public void shouldAcceptAllRequests() {
         assertTrue(new JPATransactionInterceptor(null, null).accepts(null));


### PR DESCRIPTION
This change only commits transaction if is active. 

And regarding the docs, <code>EntityManager.getTransaction()</code> never returns <code>null</code>, so I remove this condition.
